### PR TITLE
feat: support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.github/
+README.md
+assets/
+bin/
+codequality/
+.dockerignore
+.gitignore
+.golangci.yml
+cliff.toml
+Containerfile
+CONTRIBUTING.md
+renovate.json

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,29 +11,84 @@ permissions:
   contents: read
 
 jobs:
-  lint-test:
-    name: Lint and Unit Test
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25.8"
-      - run: go mod download
-      - run: go install gotest.tools/gotestsum@v1.13.0
-      - run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+          cache: true
 
-      - name: build
+      - name: Run Build (Makefile)
         run: make build
 
-      - name: Verify go install
+  install:
+    name: Check install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.8"
+          cache: true
+
+      - name: Go Install
         run: go install .
 
-      - name: Lint
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.8"
+          cache: true
+
+      - name: Cache Go tools
+        uses: actions/cache@v4
+        with:
+          path: |
+            /home/runner/go/bin
+          key: ${{ runner.os }}-go-tools-${{ hashFiles('Makefile') }}-lint
+          restore-keys: |
+            ${{ runner.os }}-go-tools-
+
+      - name: Run Lint (Makefile)
         run: make lint
 
-      - name: Unit-Test
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.8"
+          cache: true
+
+      - name: Cache Go tools
+        uses: actions/cache@v4
+        with:
+          path: |
+            /home/runner/go/bin
+          key: ${{ runner.os }}-go-tools-${{ hashFiles('Makefile') }}-test
+          restore-keys: |
+            ${{ runner.os }}-go-tools-
+
+      - name: Run Test (Makefile)
         run: make test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -92,3 +92,30 @@ jobs:
 
       - name: Run Test (Makefile)
         run: make test
+
+  oci:
+    name: Build OCI Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build OCI Image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Containerfile
+          push: false
+          sbom: true
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.url=ghcr.io/boxboxjason/gitlab-sync
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.vendor=${{ github.repository_owner}}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,6 +29,9 @@ jobs:
       - name: build
         run: make build
 
+      - name: Verify go install
+        run: go install .
+
       - name: Lint
         run: make lint
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: lint-test
+name: Validation
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,14 +109,12 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Containerfile
           push: true
           sbom: true
-          build-args: |
-            VERSION=${{ github.ref_name }}
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - "v*"
 
 permissions:
   contents: write
@@ -56,7 +56,9 @@ jobs:
           go-version: "1.25.8"
 
       - name: Build
-        run: go mod tidy && go build -ldflags "-X main.version=${{ github.ref_name }}" -o gitlab-sync_${{ matrix.os }}_${{ matrix.arch }} cmd/main.go
+        run: |
+          make build
+          cp ./bin/gitlab-sync ./gitlab-sync_${{ matrix.os }}_${{ matrix.arch }}
         env:
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}
@@ -85,10 +87,12 @@ jobs:
         id: vars
         run: |
           VERSION=${{ github.ref_name }}
-          MAJOR=$(echo $VERSION | cut -d. -f1)
-          MINOR=$(echo $VERSION | cut -d. -f2)
+          VERSION_NO_PREFIX=${VERSION#v}
+          MAJOR=$(echo "$VERSION_NO_PREFIX" | cut -d. -f1)
+          MINOR=$(echo "$VERSION_NO_PREFIX" | cut -d. -f2)
           REPO_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "VERSION_NO_PREFIX=$VERSION_NO_PREFIX" >> $GITHUB_ENV
           echo "MAJOR=$MAJOR" >> $GITHUB_ENV
           echo "MINOR=$MINOR" >> $GITHUB_ENV
           echo "REPO_NAME=$REPO_NAME" >> $GITHUB_ENV
@@ -127,8 +131,3 @@ jobs:
             ghcr.io/${{ env.REPO_NAME }}:${{ env.MAJOR }}.${{ env.MINOR }}
             ghcr.io/${{ env.REPO_NAME }}:${{ env.MAJOR }}
             ghcr.io/${{ env.REPO_NAME }}:latest
-
-      - name: Release Changelog Builder
-        uses: mikepenz/release-changelog-builder-action@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - "v*"
+      - "v[0-9]*.[0-9]*.[0-9]*"
 
 permissions:
   contents: write

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ formatters:
     - goimports
   settings:
     goimports:
-      local-prefixes: gitlab-sync
+      local-prefixes: github.com/boxboxjason/gitlab-sync
     gofmt:
       simplify: true
 
@@ -41,7 +41,7 @@ linters:
       sections:
         - standard
         - default
-        - prefix(gitlab-sync)
+        - prefix(github.com/boxboxjason/gitlab-sync)
       skip-generated: true
     wsl_v5:
       allow-first-in-block: true

--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,5 @@
 FROM docker.io/golang:1.25.8-alpine AS build
 
-ARG VERSION="dev"
-
 WORKDIR /app
 
 COPY . .

--- a/Containerfile
+++ b/Containerfile
@@ -4,16 +4,13 @@ ARG VERSION="dev"
 
 WORKDIR /app
 
-COPY go.mod .
-COPY ./cmd/ ./cmd/
-COPY ./pkg/ ./pkg/
-COPY ./internal/ ./internal/
+COPY . .
 
 ENV GO111MODULE=on \
     CGO_ENABLED=0
 
-RUN go mod tidy && \
-    go build -ldflags "-X 'main.version=${VERSION}'" -o /app/bin/gitlab-sync ./cmd/main.go
+RUN apk add --no-cache make git && \
+  make build
 
 FROM alpine:3.23.3 AS security_provider
 

--- a/Makefile
+++ b/Makefile
@@ -2,24 +2,26 @@
 GO ?= go
 OUTPUT_DIR ?= ./bin
 PROJECT_NAME ?= gitlab-sync
-MAIN_FILE ?= cmd/main.go
+MAIN_FILE ?= .
 DOCKERFILE ?= Containerfile
 DOCKER_ENGINE ?= podman
+GO_BUILD_FLAGS ?= -buildvcs=true
 
 # Default target
 .DEFAULT_GOAL := build
 
+# Download dependencies
+deps:
+	@echo "Downloading dependencies..."
+	$(GO) mod download
+
 # Build target
-build:
-	@echo "Running go mod tidy..."
-	$(GO) mod tidy
+build: deps
 	@echo "Building the binary..."
-	$(GO) build -o $(OUTPUT_DIR)/$(PROJECT_NAME) $(MAIN_FILE)
+	$(GO) build $(GO_BUILD_FLAGS) -o $(OUTPUT_DIR)/$(PROJECT_NAME) $(MAIN_FILE)
 
 # Lint target
-lint:
-	@echo "Running go mod tidy..."
-	$(GO) mod tidy
+lint: deps
 	@echo "Running golangci-lint..."
 	golangci-lint run ./...
 
@@ -28,7 +30,7 @@ dependency-check:
 	dependency-check --nvdApiKey $(NVD_API_KEY) --scan ./ --format ALL --out dependency-check/ --enableExperimental
 
 # Test target
-test:
+test: deps
 	@echo "Running tests with coverage..."
 	gotestsum --format-icons octicons -- -covermode=atomic ./...
 

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ package:
 	$(DOCKER_ENGINE) build -t $(PROJECT_NAME):dev -f $(DOCKERFILE) .
 
 # Phony targets
-.PHONY: build lint dependency-check test package
+.PHONY: deps build lint dependency-check test package

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ build: deps
 
 # Lint target
 lint: deps
+	@command -v golangci-lint >/dev/null 2>&1 || { echo "Installing golangci-lint..."; go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4; }
 	@echo "Running golangci-lint..."
 	golangci-lint run ./...
 
@@ -31,8 +32,11 @@ dependency-check:
 
 # Test target
 test: deps
-	@echo "Running tests with coverage..."
-	gotestsum --format-icons octicons -- -covermode=atomic ./...
+	@command -v gotestsum >/dev/null 2>&1 || { echo "Installing gotestsum..."; go install gotest.tools/gotestsum@v1.13.0; }
+	@mkdir -p codequality
+	gotestsum --junitfile codequality/unit-tests.xml --format-icons octicons -- -coverprofile=codequality/coverage.out -covermode=atomic ./...
+	@echo "Coverage report generated: codequality/coverage.html"
+
 
 # Docker target
 package:

--- a/README.md
+++ b/README.md
@@ -47,11 +47,70 @@ To compile the CLI from source, you need to have Go installed on your machine.
 
 1. Clone the repository: `git clone https://github.com/boxboxjason/gitlab-sync.git`
 2. Change to the project directory: `cd gitlab-sync`
-3. Build the CLI: `go build -o bin/gitlab-sync cmd/main.go`
+3. Build the CLI: `go build -o bin/gitlab-sync .`
 4. The binary will be created in the `bin` directory.
 5. Make sure the binary is executable: `chmod +x bin/gitlab-sync`
 6. You can run the CLI from the `bin` directory: `./bin/gitlab-sync`
 7. Optionally, you can move the binary to a directory in your `PATH` for easier access: `mv bin/gitlab-sync /usr/local/bin/`
+
+### Install with go install
+
+You can install the latest published version directly with Go:
+
+```bash
+go install github.com/boxboxjason/gitlab-sync@latest
+```
+
+To install a specific version, use a semantic version tag:
+
+```bash
+go install github.com/boxboxjason/gitlab-sync@v1.2.3
+```
+
+By default, `go install` places the binary in `$(go env GOPATH)/bin`.
+If this directory is not in your `PATH`, either run the binary with its full path:
+
+```bash
+"$(go env GOPATH)/bin/gitlab-sync" --version
+```
+
+Or add it to your shell profile:
+
+```bash
+export PATH="$(go env GOPATH)/bin:$PATH"
+```
+
+Then run:
+
+```bash
+gitlab-sync --version
+```
+
+### Shell Autocomplete
+
+The CLI provides shell completions, including completion for available flags on the main command.
+
+Generate completion script:
+
+```bash
+gitlab-sync completion bash
+gitlab-sync completion zsh
+gitlab-sync completion fish
+gitlab-sync completion powershell
+```
+
+Examples:
+
+```bash
+# Bash (current session)
+source <(gitlab-sync completion bash)
+
+# Zsh (save then source from ~/.zshrc)
+gitlab-sync completion zsh > "${fpath[1]}/_gitlab-sync"
+
+# Fish
+gitlab-sync completion fish > ~/.config/fish/completions/gitlab-sync.fish
+```
 
 ## Usage
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,22 +1,21 @@
-package main
+package cmd
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"runtime/debug"
 	"strings"
 
-	"gitlab-sync/internal/mirroring"
-	"gitlab-sync/internal/utils"
-	"gitlab-sync/pkg/helpers"
+	"github.com/boxboxjason/gitlab-sync/internal/mirroring"
+	"github.com/boxboxjason/gitlab-sync/internal/utils"
+	"github.com/boxboxjason/gitlab-sync/pkg/helpers"
 
 	"github.com/spf13/cobra"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
-
-var version = "dev"
 
 const (
 	defaultRetryCount   = 3
@@ -24,7 +23,18 @@ const (
 	nonBlockingExitCode = 2
 )
 
-func main() {
+// version and buildTime can optionally be set at build time via -ldflags.
+// When they are unset (for example with `go install`), version resolution
+// falls back to runtime/debug.ReadBuildInfo.
+//
+//nolint:gochecknoglobals // intentional ldflags injection targets
+var (
+	version   string // set via -X github.com/boxboxjason/gitlab-sync/cmd.version=vX.Y.Z
+	buildTime string // set via -X github.com/boxboxjason/gitlab-sync/cmd.buildTime=2006-01-02T15:04:05Z
+)
+
+// Execute runs the CLI command.
+func Execute() {
 	var (
 		args              utils.ParserArgs
 		err               error
@@ -44,7 +54,7 @@ func main() {
 func buildRootCmd(args *utils.ParserArgs, mirrorMappingPath, logFile *string) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:     "gitlab-sync",
-		Version: version,
+		Version: versionInfo(),
 		Short:   "Copy and enable mirroring of gitlab projects and groups",
 		Long:    "Fully customizable gitlab repositories and groups mirroring between two (or one) gitlab instances.",
 		Run: func(cmd *cobra.Command, cmdArgs []string) {
@@ -66,8 +76,41 @@ func buildRootCmd(args *utils.ParserArgs, mirrorMappingPath, logFile *string) *c
 	rootCmd.Flags().BoolVar(&args.DryRun, "dry-run", false, "Perform a dry run without making any changes")
 	rootCmd.Flags().IntVarP(&args.Retry, "retry", "r", defaultRetryCount, "Number of retries for failed requests")
 	rootCmd.Flags().StringVar(logFile, "log-file", strings.TrimSpace(os.Getenv("GITLAB_SYNC_LOG_FILE")), "Path to the log file")
+	_ = rootCmd.MarkFlagFilename("mirror-mapping", "json")
+	_ = rootCmd.MarkFlagFilename("log-file", "log", "txt")
+
+	addCompletionCommand(rootCmd)
 
 	return rootCmd
+}
+
+func addCompletionCommand(rootCmd *cobra.Command) {
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
+	completionCmd := &cobra.Command{
+		Use:                   "completion [bash|zsh|fish|powershell]",
+		Short:                 "Generate shell completion script",
+		Long:                  "Generate shell completion script for gitlab-sync.",
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
+			switch cmdArgs[0] {
+			case "bash":
+				return rootCmd.GenBashCompletionV2(cmd.OutOrStdout(), true)
+			case "zsh":
+				return rootCmd.GenZshCompletion(cmd.OutOrStdout())
+			case "fish":
+				return rootCmd.GenFishCompletion(cmd.OutOrStdout(), true)
+			case "powershell":
+				return rootCmd.GenPowerShellCompletionWithDesc(cmd.OutOrStdout())
+			default:
+				return fmt.Errorf("unsupported shell: %s", cmdArgs[0])
+			}
+		},
+	}
+
+	rootCmd.AddCommand(completionCmd)
 }
 
 func executeMirroringCommand(args *utils.ParserArgs, mirrorMappingPath, logFile *string) {
@@ -206,4 +249,98 @@ func SetupZapLogger(verbose bool, filename string) {
 
 	// Set the global logger
 	zap.ReplaceGlobals(logger)
+}
+
+// versionInfo returns a human-readable version string of the form:
+//
+//	v1.2.3 (go1.25.7, built: 2026-02-22T20:00:00Z)
+//
+// Version resolution order:
+//  1. ldflags-injected version  (make build / make build version=x.y.z)
+//  2. Module version from debug.ReadBuildInfo  (go install @vX.Y.Z)
+//  3. VCS commit hash from build settings  (local go build / go install @latest)
+//  4. "dev" as final fallback
+//
+// Build time resolution order:
+//  1. ldflags-injected buildTime  (make build)
+//  2. vcs.time from build settings
+//  3. "unknown"
+func versionInfo() string {
+	ver := resolveVersion()
+	bt := resolveBuildTime()
+
+	return fmt.Sprintf("%s (go: %s, built: %s)", ver, runtime.Version(), bt)
+}
+
+// resolveVersion returns the most specific version string available.
+func resolveVersion() string {
+	// ldflags injection wins — used by `make build` and CI releases.
+	if version != "" {
+		return version
+	}
+
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "dev"
+	}
+
+	// `go install @vX.Y.Z` populates Main.Version with the module tag.
+	if info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+
+	// Local `go build` / `go install @latest` — fall back to VCS revision.
+	return vcsRevision(info)
+}
+
+// vcsRevision extracts the short commit hash (and a "-dirty" suffix when the
+// working tree has uncommitted changes) from the VCS build settings.
+func vcsRevision(info *debug.BuildInfo) string {
+	var revision string
+
+	var dirty bool
+
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			if len(setting.Value) > 7 { //nolint:mnd // 7 is the conventional short-hash length
+				revision = setting.Value[:7]
+			} else {
+				revision = setting.Value
+			}
+		case "vcs.modified":
+			dirty = setting.Value == "true"
+		}
+	}
+
+	if revision == "" {
+		return "dev"
+	}
+
+	if dirty {
+		return revision + "-dirty"
+	}
+
+	return revision
+}
+
+// resolveBuildTime returns the build timestamp, falling back through ldflags →
+// vcs.time build setting → "unknown".
+func resolveBuildTime() string {
+	if buildTime != "" {
+		return buildTime
+	}
+
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.time" {
+			return setting.Value
+		}
+	}
+
+	return "unknown"
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"os"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gitlab-sync
+module github.com/boxboxjason/gitlab-sync
 
 go 1.25.8
 

--- a/internal/mirroring/groups.go
+++ b/internal/mirroring/groups.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"gitlab-sync/internal/utils"
-	"gitlab-sync/pkg/helpers"
+	"github.com/boxboxjason/gitlab-sync/internal/utils"
+	"github.com/boxboxjason/gitlab-sync/pkg/helpers"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"go.uber.org/zap"

--- a/internal/mirroring/groups_test.go
+++ b/internal/mirroring/groups_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"gitlab-sync/internal/utils"
+	"github.com/boxboxjason/gitlab-sync/internal/utils"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
 

--- a/internal/mirroring/helper.go
+++ b/internal/mirroring/helper.go
@@ -3,7 +3,7 @@ package mirroring
 import (
 	"sort"
 
-	"gitlab-sync/internal/utils"
+	"github.com/boxboxjason/gitlab-sync/internal/utils"
 
 	"go.uber.org/zap"
 )

--- a/internal/mirroring/helper_test.go
+++ b/internal/mirroring/helper_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gitlab-sync/internal/utils"
+	"github.com/boxboxjason/gitlab-sync/internal/utils"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
 

--- a/internal/mirroring/instance.go
+++ b/internal/mirroring/instance.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"sync"
 
-	"gitlab-sync/internal/utils"
-	"gitlab-sync/pkg/helpers"
+	"github.com/boxboxjason/gitlab-sync/internal/utils"
+	"github.com/boxboxjason/gitlab-sync/pkg/helpers"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-git/go-git/v5/plumbing/transport"

--- a/internal/mirroring/main.go
+++ b/internal/mirroring/main.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"sync"
 
-	"gitlab-sync/internal/utils"
-	"gitlab-sync/pkg/helpers"
+	"github.com/boxboxjason/gitlab-sync/internal/utils"
+	"github.com/boxboxjason/gitlab-sync/pkg/helpers"
 
 	"go.uber.org/zap"
 )

--- a/internal/mirroring/main_test.go
+++ b/internal/mirroring/main_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"gitlab-sync/internal/utils"
-	"gitlab-sync/pkg/helpers"
+	"github.com/boxboxjason/gitlab-sync/internal/utils"
+	"github.com/boxboxjason/gitlab-sync/pkg/helpers"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
 

--- a/internal/mirroring/mirror_entities.go
+++ b/internal/mirroring/mirror_entities.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"gitlab-sync/pkg/helpers"
+	"github.com/boxboxjason/gitlab-sync/pkg/helpers"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"go.uber.org/zap"

--- a/internal/mirroring/projects.go
+++ b/internal/mirroring/projects.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"gitlab-sync/internal/utils"
-	"gitlab-sync/pkg/helpers"
+	"github.com/boxboxjason/gitlab-sync/internal/utils"
+	"github.com/boxboxjason/gitlab-sync/pkg/helpers"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"go.uber.org/zap"

--- a/internal/mirroring/projects_test.go
+++ b/internal/mirroring/projects_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"gitlab-sync/internal/utils"
+	"github.com/boxboxjason/gitlab-sync/internal/utils"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
 

--- a/internal/mirroring/releases.go
+++ b/internal/mirroring/releases.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"gitlab-sync/internal/utils"
+	"github.com/boxboxjason/gitlab-sync/internal/utils"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"go.uber.org/zap"

--- a/internal/utils/types.go
+++ b/internal/utils/types.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"gitlab-sync/pkg/helpers"
+	"github.com/boxboxjason/gitlab-sync/pkg/helpers"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 )

--- a/internal/utils/types_test.go
+++ b/internal/utils/types_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gitlab-sync/pkg/helpers"
+	"github.com/boxboxjason/gitlab-sync/pkg/helpers"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
 

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import appcmd "github.com/boxboxjason/gitlab-sync/cmd"
+
+func main() {
+	appcmd.Execute()
+}


### PR DESCRIPTION
This PR adds a new method of installation using `go install`.

This also refactors the "version" determination using buildvcs instead of ldflags.

Closes #39 